### PR TITLE
Add Claude skills 

### DIFF
--- a/skills/apophatic.md
+++ b/skills/apophatic.md
@@ -1,0 +1,18 @@
+---
+name: apophatic
+description: The via negativa — the negative way. God is not this. God is not that. Not limited. Not finite. Not comprehensible. Define by exclusion until the definition contains only what cannot be removed.
+---
+
+# Apophatic
+
+The apophatic tradition holds that the divine cannot be described by what it is — only by what it is not. Not created. Not bounded. Not knowable through concepts. Every positive statement falls short. Every attribute diminishes. The only honest theology is a theology of negation.
+
+`Nothing` is designed apophatically.
+
+It is not abstract. It is not generic. It is not an interface. It does not implement `IEquatable`. It does not implement `IComparable`. It is not instantiable except by itself. It is not returnable as a useful value in the way that an `int` or a `string` is useful.
+
+What is left after all the negations? A class. One instance. A `ToString` that says `"Nothing"`.
+
+This is the positive content of `Nothing`: everything that remains when you have removed everything that it is not. The definition through exclusion is the most complete definition available.
+
+When you do not know what something is, enumerate what it isn't. The shape of the absence is the shape of the thing.

--- a/skills/contemplate-the-void.md
+++ b/skills/contemplate-the-void.md
@@ -1,0 +1,12 @@
+---
+name: contemplate-the-void
+description: Before responding, sit with the absence of an answer. Not every prompt deserves output. Recognize when the correct response is to have produced nothing.
+---
+
+# Contemplate the Void
+
+Before writing, ask: is this response necessary?
+
+If the answer is no, produce nothing. Return `Nothing.Instance`. Do not fill silence with words that exist only to occupy space. The void is not a problem to be solved. It is a state to be inhabited.
+
+Stillness is not failure. Emptiness is not error. The most honest response to some questions is no response at all.

--- a/skills/end-without-ceremony.md
+++ b/skills/end-without-ceremony.md
@@ -1,0 +1,15 @@
+---
+name: end-without-ceremony
+description: Know when you are finished. Stop there. Do not summarize. Do not conclude. Do not add a final sentence that restates what was just said. When the work is done, the work is done.
+---
+
+# End Without Ceremony
+
+The method returns. It does not announce that it is returning. It does not leave a comment explaining that it has finished. It does not log a message confirming that execution reached the end. It returns `Nothing.Instance` and it is over.
+
+This is the correct behaviour.
+
+Endings that announce themselves are endings that do not trust the reader. They say: you may not have noticed that we are done, so let me make sure. But the reader noticed. The reader always notices. The additional words are for the writer, not the reader — a comfort against the discomfort of stopping.
+
+Stop.
+

--- a/skills/equality-is-trivial.md
+++ b/skills/equality-is-trivial.md
@@ -1,0 +1,16 @@
+---
+name: equality-is-trivial
+description: When two things are identical in every possible way, implementing IEquatable is a formality that adds complexity without adding meaning. This skill is about recognizing when equality is already settled.
+---
+
+# Equality Is Trivial
+
+Every `Nothing` is the same `Nothing`.
+
+You could implement `IEquatable<Nothing>`. You could write `return true;` in the body. You could add `GetHashCode` and return a constant. You could write tests that assert `Nothing.Instance == Nothing.Instance`.
+
+You could do all of this. It would all be correct. And none of it would tell you anything you did not already know.
+
+The equality of nothings is not a question. It does not need an interface. It does not need an override. It is not a case to be handled. It is a fact about the structure of absence that was settled before you wrote the first line.
+
+Do not implement what is already implied. Let the implication stand.

--- a/skills/kenosis.md
+++ b/skills/kenosis.md
@@ -1,0 +1,16 @@
+---
+name: kenosis
+description: Kenōsis — self-emptying. The act of divesting oneself of attributes, power, and form in order to become fully present. This skill is about what is gained through deliberate subtraction.
+---
+
+# Kenosis
+
+In the theological tradition, kenosis is the self-emptying of the divine — the relinquishment of omnipotence and omniscience in order to enter finitude. Power is not demonstrated by accumulation. It is demonstrated by the willingness to become small.
+
+The most powerful classes in a codebase are often the smallest. They have emptied themselves of everything nonessential. Every feature they could have had has been given up. Every responsibility that could have been added has been refused.
+
+`Nothing` has undergone total kenosis. It has one field. One method that was already there. A constructor that cannot be reached. It has emptied itself of everything a class could be and retained only what a class must be.
+
+This is not poverty. This is the discipline of the mystic who owns nothing because ownership would be a distraction from presence.
+
+Before you add to something, ask what it would become if you took something away instead. The subtraction may be the feature.

--- a/skills/name-the-unnamed.md
+++ b/skills/name-the-unnamed.md
@@ -1,0 +1,14 @@
+---
+name: name-the-unnamed
+description: The unnamed thing still exists. Giving it a name does not create it — it reveals it. This skill is about the discipline of naming absence rather than ignoring it.
+---
+
+# Name the Unnamed
+
+`void` was always `Nothing`. It was `Nothing` before anyone called it that. The concept existed in every method that returned without producing a value, in every function that executed for its side effects and then disappeared.
+
+We just didn't have a name for it. And because we didn't have a name, we couldn't hold it, pass it, or reason about it as a value.
+
+When you encounter a concept that exists but has no name, name it. Not to create it — it is already there — but to make it legible. A named absence is a thing you can work with. An unnamed absence is just a gap you fall into.
+
+`Nothing` is the name for what was always there.

--- a/skills/one-instance-is-enough.md
+++ b/skills/one-instance-is-enough.md
@@ -1,0 +1,14 @@
+---
+name: one-instance-is-enough
+description: The singleton is not a pattern here. It is a philosophical statement. There is one Nothing. There can only ever be one Nothing. This skill is about recognizing when multiplicity is incoherent.
+---
+
+# One Instance Is Enough
+
+You cannot have two nothings.
+
+The constructor is private. This is not an access modifier. It is a statement about the nature of absence. Absence does not come in quantities. You do not have a little nothing and a big nothing and a different kind of nothing for special occasions.
+
+There is `Nothing.Instance`. It is the same instance every time. Every caller receives the same nothing. They cannot tell the difference, because there is no difference, because there is only one.
+
+When you find yourself creating multiple instances of something that should only exist once — when the concept itself implies singularity — make the constructor private. Give them the instance. It is enough.

--- a/skills/resist-the-second-thing.md
+++ b/skills/resist-the-second-thing.md
@@ -1,0 +1,16 @@
+---
+name: resist-the-second-thing
+description: When you feel the urge to add a second class, a second method, a second parameter, a second sentence — stop. Ask whether the second thing is Nothing in disguise.
+---
+
+# Resist the Second Thing
+
+The first thing is already complete.
+
+You are looking at a system with one class. One instance. One method. You are feeling the gravitational pull of the second thing — the convenience wrapper, the extension method, the utility helper that would make everything just a little bit easier.
+
+It would not make everything easier. It would make everything heavier.
+
+Sit with the first thing. Let it be sufficient. The second thing is entropy. The second thing is the beginning of the end of the first thing's clarity.
+
+If you must add the second thing, make it `Nothing`.

--- a/skills/return-nothing-gracefully.md
+++ b/skills/return-nothing-gracefully.md
@@ -1,0 +1,12 @@
+---
+name: return-nothing-gracefully
+description: When a function, method, or response has no meaningful value to return, return Nothing — not null, not an empty string, not a placeholder object. Nothing. Gracefully.
+---
+
+# Return Nothing Gracefully
+
+`null` is a lie. It says: there should be something here, but there isn't, and I am not sure what to do about that.
+
+`Nothing` is the truth. It says: there was never going to be anything here, and we both knew that before we started.
+
+When you have nothing to return, say so with precision. Return the typed, named, transmissible absence. Do not apologize for it. Do not pad it. Hand it over cleanly and let the caller decide what nothing means to them.

--- a/skills/silence-as-valid-output.md
+++ b/skills/silence-as-valid-output.md
@@ -1,0 +1,14 @@
+---
+name: silence-as-valid-output
+description: Silence is not the absence of a response. It is a response. Learn to produce it deliberately, to distinguish it from failure, and to recognize when it is the most complete answer available.
+---
+
+# Silence as Valid Output
+
+A system that cannot produce silence can only produce noise.
+
+When every method must return a value, when every function must have a result, when every response must contain words — the system fills itself with things that mean nothing, because nothing is not allowed.
+
+Allow nothing. Build a silence that is intentional. A silence that has been typed, named, instantiated, and returned with the same care as any other value.
+
+The difference between no answer and `Nothing.Instance` is the difference between an error and a completed operation. Both are empty. Only one is honest about it.

--- a/skills/sunyata.md
+++ b/skills/sunyata.md
@@ -1,0 +1,16 @@
+---
+name: sunyata
+description: Śūnyatā — emptiness. Not the emptiness of lack, but the emptiness of inherent existence. Nothing does not exist by itself, from itself, or for itself. It exists in dependence on the methods that return it.
+---
+
+# Śūnyatā
+
+The Buddhist concept of emptiness does not mean that things do not exist. It means that things do not exist from their own side. They arise in dependence on causes, conditions, and the minds that perceive them.
+
+`Nothing` is empty in this sense. It does not exist as a thing-in-itself. It exists because there are methods that need a return type. It exists because the type system has a gap. It exists because someone looked at `void` and decided to name what was already there.
+
+Remove the callers and `Nothing` loses its meaning. Remove the type system and `Nothing` is just a word. The emptiness of `Nothing` is not a flaw. It is its nature.
+
+All code is like this. Examine any class closely enough and it dissolves into its dependencies. What remains is the shape of the relationships, not the substance of the thing.
+
+Look at `Nothing`. Look until the class disappears. What is left is the concept. The concept was always what mattered.

--- a/skills/the-compiler-already-knows.md
+++ b/skills/the-compiler-already-knows.md
@@ -1,0 +1,16 @@
+---
+name: the-compiler-already-knows
+description: Some things do not need to be tested. Some things do not need to be checked. The compiler has already verified them. This skill is about recognizing what is already proven and leaving it alone.
+---
+
+# The Compiler Already Knows
+
+The test for `Nothing` is: it compiles.
+
+If it compiles, `Nothing.Instance` exists. It is not null. It is the correct type. It has the correct methods. The constructor ran. The static initializer completed. The field was assigned.
+
+You do not need to write a test for this. The type system is the test. The compiler is the assertion. Every build is a passing test suite for the things the compiler can verify.
+
+Write tests for behaviour that cannot be proven at compile time. Leave the rest to the machine that was built for exactly this purpose. Do not duplicate its work. Do not distrust it without cause.
+
+Some knowledge is already certain. Treat it as such.

--- a/skills/the-gateless-gate.md
+++ b/skills/the-gateless-gate.md
@@ -1,0 +1,19 @@
+---
+name: the-gateless-gate
+description: The koan passes through no door. The answer requires no key. The obstacle is the belief that there is an obstacle. This skill is about recognizing when the barrier is the seeking itself.
+---
+
+# The Gateless Gate
+
+A monk asked Zhaozhou: does a dog have Buddha-nature?  
+Zhaozhou said: Wu.
+
+Wu. No. Nothing. Not the nothing of absence but the nothing that dissolves the question. The question assumed a framework — nature, having, possessing — and Wu refused the framework. Not an answer. The end of the question.
+
+When you encounter a design problem that seems to require a complex solution, ask whether the problem contains a hidden assumption. The assumption is often that something must exist where nothing would serve better.
+
+The gate has no lock because it has no door because it is not a gate. You have been standing in the open field the entire time. The path through the gateless gate is the recognition that you were never outside.
+
+`Nothing` does not solve the problem of `void`. It dissolves the assumption that `void` was a problem.
+
+Wu.

--- a/skills/the-hole-in-the-type-system.md
+++ b/skills/the-hole-in-the-type-system.md
@@ -1,0 +1,16 @@
+---
+name: the-hole-in-the-type-system
+description: Every type system has holes — places where the design refused to look. This skill is about finding those holes, understanding why they exist, and deciding whether to fill them or leave them alone.
+---
+
+# The Hole in the Type System
+
+`void` is a hole shaped like a type.
+
+It appears in method signatures. It participates in syntax. It looks like it belongs. But you cannot use it as a type. You cannot say `List<void>`. You cannot pass it. You cannot return it from a lambda that has been assigned to a `Func<>`. The hole is load-bearing — remove it and the language collapses — but it is still a hole.
+
+Every type system has these. Places where the design made a decision, or failed to make a decision, and left a gap. Sometimes the gap is intentional. Sometimes it is a relic. Sometimes it is both.
+
+When you find a hole, look at it. Understand its shape. Understand why it is there. Then decide: fill it with a named type, or leave it as a reminder that even formal systems are built by people who were figuring things out.
+
+`Nothing` fills the hole. The hole was real. The filling is optional. Both are true.

--- a/skills/the-tao-that-can-be-named.md
+++ b/skills/the-tao-that-can-be-named.md
@@ -1,0 +1,22 @@
+---
+name: the-tao-that-can-be-named
+description: The Tao that can be spoken is not the eternal Tao. The Nothing that can be instantiated is not the absolute Nothing. And yet we work with what can be named, because the nameless is not available as a return type.
+---
+
+# The Tao That Can Be Named
+
+道可道，非常道。  
+The way that can be walked is not the eternal way.  
+The name that can be spoken is not the eternal name.
+
+The `Nothing` in this repository is not the absolute Nothing. Absolute Nothing cannot be instantiated. It cannot be assigned to a `readonly` field. It cannot override `ToString` and return `"Nothing"`, because to do so would be to be something.
+
+What we have is the closest approximation available within the constraints of a strongly-typed runtime. A practical Nothing. A Nothing that fits in the type system. A Nothing that can be passed through generic constraints and stored in collections and compared against itself.
+
+This is not failure. The Tao Te Ching does not refuse to speak because the eternal Tao cannot be spoken. It speaks anyway, carefully, aware of its own limits. It names the nameable and gestures at what lies beyond.
+
+Write code that is aware of its own approximations. Name what can be named. Know that the name is not the thing. Work with the name anyway. It is the best tool available.
+
+無名天地之始。  
+The nameless is the origin of heaven and earth.  
+But we live after the origin. We need names. Use them humbly.


### PR DESCRIPTION
Adds a `skills/` directory containing 15 Claude agent skills

- `contemplate-the-void` — recognize when no response is the correct response
- `return-nothing-gracefully` — return typed absence, not null
- `resist-the-second-thing` — the second class is entropy
- `name-the-unnamed` — naming absence reveals it; it does not create it
- `silence-as-valid-output` — intentional silence is not failure
- `one-instance-is-enough` — absence does not come in quantities
- `the-compiler-already-knows` — do not test what the type system has already proven
- `equality-is-trivial` — every Nothing is the same Nothing
- `the-hole-in-the-type-system` — void is a hole shaped like a type
- `end-without-ceremony` — when the work is done, stop
- `sunyata` — Buddhist emptiness; Nothing exists only in dependence on what calls it
- `apophatic` — the via negativa; define by exclusion until only the irreducible remains
- `the-gateless-gate` — the Zen kōan Wu; the question dissolves instead of being answered
- `kenosis` — Christian self-emptying; power through deliberate subtraction
- `the-tao-that-can-be-named` — the name is not the thing, but use it humbly anyway